### PR TITLE
Remove separate Genesis API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,6 @@ Thus, I have created a `debug()` function that runs when `example.py` is execute
 
 **Note:** I have done my best to remove the sensitive parts from debugging, but I do not guarantee that no sensitive data is printed to the debug file. I have no intention of using it maliciously, but if you post the file publicly on GitHub, please make sure you remove anything you feel might be suspicious of sharing.
 
-## Supported APIs:
-* `classic`, default, online access url is https://online.thermia.se
-* `genesis`, online access url is https://online-genesis.thermia.se
-
 ## How to use api:
 See [example.py](https://github.com/klejejs/python-thermia-online-api/blob/main/example.py) file for examples.
 

--- a/ThermiaOnlineAPI/__init__.py
+++ b/ThermiaOnlineAPI/__init__.py
@@ -3,15 +3,14 @@ from typing import List
 from ThermiaOnlineAPI.api.ThermiaAPI import ThermiaAPI
 from ThermiaOnlineAPI.exceptions import AuthenticationException, NetworkException
 from ThermiaOnlineAPI.model.HeatPump import ThermiaHeatPump
-from ThermiaOnlineAPI.const import THERMIA_API_TYPE_CLASSIC
 
 
 class Thermia:
-    def __init__(self, username, password, api_type=THERMIA_API_TYPE_CLASSIC):
+    def __init__(self, username, password):
         self._username = username
         self._password = password
 
-        self.api_interface = ThermiaAPI(username, password, api_type)
+        self.api_interface = ThermiaAPI(username, password)
         self.connected = self.api_interface.authenticated
 
         self.heat_pumps = self.fetch_heat_pumps()

--- a/ThermiaOnlineAPI/api/ThermiaAPI.py
+++ b/ThermiaOnlineAPI/api/ThermiaAPI.py
@@ -17,7 +17,7 @@ from ThermiaOnlineAPI.const import (
     REG_HOT_WATER_STATUS,
     REG__HOT_WATER_BOOST,
     REG_OPERATIONMODE,
-    THERMIA_API_CONFIG_URLS_BY_API_TYPE,
+    THERMIA_CONFIG_URL,
     THERMIA_AZURE_AUTH_URL,
     THERMIA_AZURE_AUTH_CLIENT_ID_AND_SCOPE,
     THERMIA_AZURE_AUTH_REDIRECT_URI,
@@ -47,7 +47,7 @@ azure_auth_request_headers = {
 
 
 class ThermiaAPI:
-    def __init__(self, email, password, api_type):
+    def __init__(self, email, password):
         self.__email = email
         self.__password = password
         self.__token = None
@@ -68,11 +68,6 @@ class ThermiaAPI:
         )
         adapter = HTTPAdapter(max_retries=retry)
         self.__session.mount("https://", adapter)
-
-        if api_type not in THERMIA_API_CONFIG_URLS_BY_API_TYPE:
-            raise ValueError("Unknown device type: " + api_type)
-
-        self.__api_config_url = THERMIA_API_CONFIG_URLS_BY_API_TYPE[api_type]
 
         self.configuration = self.__fetch_configuration()
         self.authenticated = self.__authenticate()
@@ -514,7 +509,7 @@ class ThermiaAPI:
             )
 
     def __fetch_configuration(self):
-        request = self.__session.get(self.__api_config_url)
+        request = self.__session.get(THERMIA_CONFIG_URL)
         status = request.status_code
 
         if status != 200:

--- a/ThermiaOnlineAPI/const.py
+++ b/ThermiaOnlineAPI/const.py
@@ -2,18 +2,8 @@
 # General configuration
 ###############################################################################
 
-THERMIA_CLASSIC_API_CONFIG_URL = "https://online.thermia.se/api/configuration"
-THERMIA_GENESIS_API_CONFIG_URL = "https://online-genesis.thermia.se/api/configuration"
-
+THERMIA_CONFIG_URL = "https://online.thermia.se/api/configuration"
 THERMIA_INSTALLATION_PATH = "/api/v1/Registers/Installations/"
-
-THERMIA_API_TYPE_CLASSIC = "classic"
-THERMIA_API_TYPE_GENESIS = "genesis"
-
-THERMIA_API_CONFIG_URLS_BY_API_TYPE = {
-    THERMIA_API_TYPE_CLASSIC: THERMIA_CLASSIC_API_CONFIG_URL,
-    THERMIA_API_TYPE_GENESIS: THERMIA_GENESIS_API_CONFIG_URL,
-}
 
 ###############################################################################
 # Azure AD configuration
@@ -21,7 +11,7 @@ THERMIA_API_CONFIG_URLS_BY_API_TYPE = {
 
 THERMIA_AZURE_AUTH_URL = "https://thermialogin.b2clogin.com/thermialogin.onmicrosoft.com/b2c_1a_signuporsigninonline"
 THERMIA_AZURE_AUTH_CLIENT_ID_AND_SCOPE = "09ea4903-9e95-45fe-ae1f-e3b7d32fa385"
-THERMIA_AZURE_AUTH_REDIRECT_URI = "https://online-genesis.thermia.se/login"
+THERMIA_AZURE_AUTH_REDIRECT_URI = "https://online.thermia.se/login"
 
 ###############################################################################
 # Register groups

--- a/credentials.py
+++ b/credentials.py
@@ -1,3 +1,2 @@
 USERNAME = ""
 PASSWORD = ""
-API_TYPE = "" # classic or genesis

--- a/example.py
+++ b/example.py
@@ -1,10 +1,6 @@
 from datetime import datetime, timedelta
 from ThermiaOnlineAPI import Thermia
-from credentials import USERNAME, PASSWORD, API_TYPE
-from ThermiaOnlineAPI.const import (
-    THERMIA_API_TYPE_CLASSIC,
-    THERMIA_API_TYPE_GENESIS,
-)
+from credentials import USERNAME, PASSWORD
 
 CHANGE_HEAT_PUMP_DATA_DURING_TEST = (
     False  # Set to True if you want to change heat pump data during test
@@ -14,17 +10,7 @@ if not USERNAME or not PASSWORD:
     USERNAME = input("Enter username: ")
     PASSWORD = input("Enter password: ")
 
-if not API_TYPE:
-    api_type_number = input("Enter api type (1 = classic, 2 = genesis): ")
-    if api_type_number == "1":
-        API_TYPE = THERMIA_API_TYPE_CLASSIC
-    elif api_type_number == "2":
-        API_TYPE = THERMIA_API_TYPE_GENESIS
-    else:
-        print("Invalid api type")
-        exit(1)
-
-thermia = Thermia(USERNAME, PASSWORD, api_type=API_TYPE)
+thermia = Thermia(USERNAME, PASSWORD)
 
 print("Connected: " + str(thermia.connected))
 


### PR DESCRIPTION
It looks like Thermia has removed its separate Genesis API and migrated it under the previously considered classic API, thus, within this PR, Genesis API is removed.