### PR TITLE
Added support for setuptools-git-versioning

### DIFF
--- a/.github/workflows/publish-release-to-pypi.yaml
+++ b/.github/workflows/publish-release-to-pypi.yaml
@@ -20,16 +20,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: '3.x'
+          python-version: "3.x"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -U setuptools wheel twine
+          pip install -U -r requirements_release.txt
       - name: Build and publish release
         env:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          if [ -z ${{ github.event.inputs.version }} ]; then VERSION=${{ github.event.release.tag_name }}; else VERSION=${{ github.event.inputs.version }}; fi
-          python setup.py sdist bdist_wheel $VERSION
+          python setup.py sdist bdist_wheel
           twine upload dist/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,1 @@
-requests
-setuptools >= 74.1.0
-setuptools_git_versioning >= 2.0.0
+requests >= 2.32.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 requests
+setuptools >= 74.1.0
+setuptools_git_versioning >= 2.0.0

--- a/requirements_release.txt
+++ b/requirements_release.txt
@@ -1,0 +1,4 @@
+setuptools >= 74.1.0
+setuptools_git_versioning >= 2.0.0
+twine >= 5.1.1
+wheel >= 0.44.0

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,12 @@
 import sys
-from setuptools import setup
+import setuptools
 from pathlib import Path
 
 # read the contents of your README file
 current_directory = Path(__file__).parent
 long_description = (current_directory / "README.md").read_text()
 
-version = sys.argv[3:]
-if version:
-    version = str(version[0])
-    sys.argv.remove(version)
-else:
-    raise Exception("Version is not set")
-
-setup(
+setuptools.setup(
     name="ThermiaOnlineAPI",
     packages=[
         "ThermiaOnlineAPI",
@@ -22,7 +15,10 @@ setup(
         "ThermiaOnlineAPI.model",
         "ThermiaOnlineAPI.utils",
     ],
-    version=version,
+    setuptools_git_versioning={
+        "enabled": True,
+        "dev_template": "{tag}", 
+    },
     license="GPL-3.0",
     description="A Python API for Thermia heat pumps using https://online.thermia.se",
     long_description=long_description,
@@ -33,5 +29,6 @@ setup(
     download_url="https://github.com/klejejs/python-thermia-online-api/releases",
     keywords=["Thermia", "Online"],
     install_requires=[],
+    setup_requires=["setuptools-git-versioning"],
     classifiers=[],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-import sys
 import setuptools
 from pathlib import Path
 
@@ -17,7 +16,7 @@ setuptools.setup(
     ],
     setuptools_git_versioning={
         "enabled": True,
-        "dev_template": "{tag}", 
+        "dev_template": "{tag}",
     },
     license="GPL-3.0",
     description="A Python API for Thermia heat pumps using https://online.thermia.se",


### PR DESCRIPTION
Changed pulling the git version from the cmdline, to pulling it from the last git tag.

The tag of development branches, defaults to the last tag. 
So all you have to do is add a redirect to a fork of python-thermia-online-api in your requirements.txt and manifast.json to redirect a dev branch. 