### PR TITLE
Refactor operational and power statuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,17 +54,9 @@ To execute the example file, first run `pip install -r requirements.txt` to inst
 | `running_operational_statuses` | List of running operational statuses of the Heat Pump  |
 | `available_operational_statuses` | List of available operational statuses |
 | `available_operational_statuses_map` | Dictionary mapping operational status names to their values |
-| `operational_status_auxiliary_heater_3kw` | Auxiliary heater status for 3kw (returns `None` if unavailable) |
-| `operational_status_auxiliary_heater_6kw` | Auxiliary heater status for 6kw (returns `None` if unavailable) |
-| `operational_status_auxiliary_heater_9kw` | Auxiliary heater status for 9kw (returns `None` if unavailable) |
-| `operational_status_auxiliary_heater_12kw` | Auxiliary heater status for 12kw (returns `None` if unavailable) |
-| `operational_status_auxiliary_heater_15kw` | Auxiliary heater status for 15kw (returns `None` if unavailable) |
-| `operational_status_compressor_status` | Compressor status |
-| `operational_status_brine_pump_status` | Brine pump status |
-| `operational_status_radiator_pump_status` | Radiator pump status |
-| `operational_status_cooling_status` | Cooling status |
-| `operational_status_hot_water_status` | Hot water status |
-| `operational_status_heating_status` | Heating status |
+| `running_power_statuses` | List of running power statuses of the Heat Pump |
+| `available_power_statuses` | List of available power statuses |
+| `available_power_statuses_map` | Dictionary mapping power status names to their values |
 | `operational_status_integral` | Integral |
 | `operational_status_pid` | PID |
 | --- | --- |

--- a/ThermiaOnlineAPI/const.py
+++ b/ThermiaOnlineAPI/const.py
@@ -77,6 +77,8 @@ REG_OPERATIONAL_STATUS_PRIORITY_BITMASK = (
 REG_INTEGRAL_LSD = "REG_INTEGRAL_LSD"
 REG_PID = "REG_PID"
 
+COMP_POWER_STATUS = "COMP_POWER_STATUS"
+
 ###############################################################################
 # Hot water registers
 ###############################################################################

--- a/example.py
+++ b/example.py
@@ -63,22 +63,16 @@ print(
     "Available operational statuses map: "
     + str(heat_pump.available_operational_statuses_map)
 )
-print("Auxiliary heater 3KW: " + str(heat_pump.operational_status_auxiliary_heater_3kw))
-print("Auxiliary heater 6KW: " + str(heat_pump.operational_status_auxiliary_heater_6kw))
-print("Auxiliary heater 9KW: " + str(heat_pump.operational_status_auxiliary_heater_9kw))
-print(
-    "Auxiliary heater 12KW: " + str(heat_pump.operational_status_auxiliary_heater_12kw)
-)
-print(
-    "Auxiliary heater 15KW: " + str(heat_pump.operational_status_auxiliary_heater_15kw)
-)
 
-print("Compressor status: " + str(heat_pump.operational_status_compressor_status))
-print("Brine pump status: " + str(heat_pump.operational_status_brine_pump_status))
-print("Radiator pump status: " + str(heat_pump.operational_status_radiator_pump_status))
-print("Cooling status: " + str(heat_pump.operational_status_cooling_status))
-print("Hot water status: " + str(heat_pump.operational_status_hot_water_status))
-print("Heating status: " + str(heat_pump.operational_status_heating_status))
+print("\n")
+
+print("Power status")
+print("Running power statuses: " + str(heat_pump.running_power_statuses))
+print("Available power statuses: " + str(heat_pump.available_power_statuses))
+print("Available power statuses map: " + str(heat_pump.available_power_statuses_map))
+
+print("\n")
+
 print("Integral: " + str(heat_pump.operational_status_integral))
 print("Pid: " + str(heat_pump.operational_status_pid))
 


### PR DESCRIPTION
Breaking change - removes custom properties for operational and power statuses, allows their calculation based on the existing `running_operational_statuses` and `available_operational_statuses` properties as well as the new `running_power_statuses` and `available_power_statuses` properties.