### PR TITLE
Add Prometheus metrics endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ See [example.py](https://github.com/klejejs/python-thermia-online-api/blob/main/
 To execute the example file, first run `pip install -r requirements.txt` to install the required dependencies, then run `python3 example.py` to execute the example file. You will be prompted to enter your username and password, and then the example file will run. If do not want to manually enter your credentials every time, you can edit the `credentials.py` file and add your credentials there.
 
 ### Promethues metrics endpoint
-You can use the metrics.py to start a flask server that exposes the data for Prometheus. Install the metrics requirements: ``pip install -r requirements_metrics.txt`` and then run ``python3 metrics.py`` to start the server.
+You can use the metrics.py to start a flask server that exposes the data for Prometheus. Install the metrics requirements: ``pip install -r requirements_metrics.txt`` and then run ``gunicorn -b 0.0.0.0:8000 metrics:app`` to use gunicorn to run the flask app. When the server is running you can access it at ``http://localhost:8000/metrics``
 
 ## Available functions in Thermia class:
 | Function | Description |

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Thus, I have created a `debug()` function that runs when `example.py` is execute
 **Note:** I have done my best to remove the sensitive parts from debugging, but I do not guarantee that no sensitive data is printed to the debug file. I have no intention of using it maliciously, but if you post the file publicly on GitHub, please make sure you remove anything you feel might be suspicious of sharing.
 
 ## How to use api:
+### example.py
 See [example.py](https://github.com/klejejs/python-thermia-online-api/blob/main/example.py) file for examples.
 
 To execute the example file, first run `pip install -r requirements.txt` to install the required dependencies, then run `python3 example.py` to execute the example file. You will be prompted to enter your username and password, and then the example file will run. If do not want to manually enter your credentials every time, you can edit the `credentials.py` file and add your credentials there.
+
+### Promethues metrics endpoint
+You can use the metrics.py to start a flask server that exposes the data for Prometheus. Install the metrics requirements: ``pip install -r requirements_metrics.txt`` and then run ``python3 metrics.py`` to start the server.
 
 ## Available functions in Thermia class:
 | Function | Description |

--- a/metrics.py
+++ b/metrics.py
@@ -18,7 +18,7 @@ wanted_metrics = {
     'heating_effect': {'path': ['_ThermiaHeatPump__status', 'heatingEffect'], 'description': 'Heating Effect of the heat pump'},
     'compressor_operational_time': {'path': ['_ThermiaHeatPump__group_operational_time', 2, 'registerValue'], 'description': 'Compressor Operational Time in hours'},
     'hot_water_operational_time': {'path': ['_ThermiaHeatPump__group_operational_time', 3, 'registerValue'], 'description': 'Hot Water Operational Time in hours'},
-    'desired_supply_line_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 6, 'registerValue'], 'description': 'Desired Supply Line Temperature of the heat pump'}  # New metric added
+    'desired_supply_line_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 6, 'registerValue'], 'description': 'Desired Supply Line Temperature of the heat pump'}
 }
 
 def collect_data():
@@ -58,6 +58,3 @@ def metrics():
         return Response(error_message, status=500, mimetype='text/plain')
     
     return Response(prometheus_client.generate_latest(), mimetype='text/plain')
-
-if __name__ == '__main__':
-    app.run(host="0.0.0.0", port=8000)

--- a/metrics.py
+++ b/metrics.py
@@ -1,0 +1,63 @@
+from ThermiaOnlineAPI import Thermia
+from credentials import USERNAME, PASSWORD
+from prometheus_client import start_http_server, Gauge
+from flask import Flask, Response
+import prometheus_client
+
+app = Flask(__name__)
+
+prometheus_metrics = {}
+
+wanted_metrics = {
+    'outdoor_temperature': {'path': ['_ThermiaHeatPump__status', 'outdoorTemperature'], 'description': 'Outdoor Temperature of the heat pump'},
+    'hot_water_temperature': {'path': ['_ThermiaHeatPump__status', 'hotWaterTemperature'], 'description': 'Hot Water Temperature of the heat pump'},
+    'supply_line_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 1, 'registerValue'], 'description': 'Supply Line Temperature of the heat pump'},
+    'return_line_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 2, 'registerValue'], 'description': 'Return Line Temperature of the heat pump'},
+    'brine_in_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 3, 'registerValue'], 'description': 'Brine In Temperature of the heat pump'},
+    'brine_out_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 4, 'registerValue'], 'description': 'Brine Out Temperature of the heat pump'},
+    'heating_effect': {'path': ['_ThermiaHeatPump__status', 'heatingEffect'], 'description': 'Heating Effect of the heat pump'},
+    'compressor_operational_time': {'path': ['_ThermiaHeatPump__group_operational_time', 2, 'registerValue'], 'description': 'Compressor Operational Time in hours'},
+    'hot_water_operational_time': {'path': ['_ThermiaHeatPump__group_operational_time', 3, 'registerValue'], 'description': 'Hot Water Operational Time in hours'},
+    'desired_supply_line_temperature': {'path': ['_ThermiaHeatPump__group_temperatures', 6, 'registerValue'], 'description': 'Desired Supply Line Temperature of the heat pump'}  # New metric added
+}
+
+def collect_data():
+    if not USERNAME or not PASSWORD:
+        return "Error: USERNAME and PASSWORD must be set in credentials.py"
+    
+    try:
+        thermia = Thermia(USERNAME, PASSWORD)
+        heat_pumps = thermia.fetch_heat_pumps()
+        
+        for hp in heat_pumps:
+            heat_pump_name = hp.__dict__.get('_ThermiaHeatPump__info', {}).get('name', 'unknown')
+
+            for metric, details in wanted_metrics.items():
+                value = hp.__dict__
+                for key in details['path']:
+                    if isinstance(value, dict):
+                        value = value.get(key)
+                    elif isinstance(value, list):
+                        value = value[key]
+
+                if isinstance(value, (int, float)):
+                    print(f"Registering {metric}: {value} for {heat_pump_name}")
+                    if metric not in prometheus_metrics:
+                        prometheus_metrics[metric] = Gauge(metric, details['description'], ['heat_pump_name'])
+                    prometheus_metrics[metric].labels(heat_pump_name=heat_pump_name).set(value)
+
+        return None
+
+    except Exception as e:
+        return f"Error while collecting data: {str(e)}"
+
+@app.route('/metrics')
+def metrics():
+    error_message = collect_data()
+    if error_message:
+        return Response(error_message, status=500, mimetype='text/plain')
+    
+    return Response(prometheus_client.generate_latest(), mimetype='text/plain')
+
+if __name__ == '__main__':
+    app.run(host="0.0.0.0", port=8000)

--- a/metrics.py
+++ b/metrics.py
@@ -53,8 +53,8 @@ def collect_data():
 
 @app.route('/metrics')
 def metrics():
-    error_message = collect_data()
-    if error_message:
-        return Response(error_message, status=500, mimetype='text/plain')
+    collection_status = collect_data()
+    if collection_status:
+        return Response(collection_status, status=500, mimetype='text/plain')
     
     return Response(prometheus_client.generate_latest(), mimetype='text/plain')

--- a/requirements_metrics.txt
+++ b/requirements_metrics.txt
@@ -1,3 +1,4 @@
 requests >= 2.32.3
 prometheus_client >= 0.21.0
 flask >= 3.0.3
+gunicorn >= 23.0.0

--- a/requirements_metrics.txt
+++ b/requirements_metrics.txt
@@ -1,0 +1,3 @@
+requests >= 2.32.3
+prometheus_client >= 0.21.0
+flask >= 3.0.3


### PR DESCRIPTION
The metrics.py creates a flask app that fetches data (temps and operational time) and serves it as a Prometheus endpoint.

Updated requirements (in seperate requirements_metrics.txt though) and updated readme.

Then gunicorn should be run to expose the flask app and you're able to add the endpoint to Promethues for data collection.

/Gjorret