### PR TITLE
Fixed register name

### DIFF
--- a/ThermiaOnlineAPI/const.py
+++ b/ThermiaOnlineAPI/const.py
@@ -85,7 +85,7 @@ COMP_POWER_STATUS = "COMP_POWER_STATUS"
 ###############################################################################
 
 REG_HOT_WATER_STATUS = "REG_HOT_WATER_STATUS"
-REG__HOT_WATER_BOOST = "REG__HOT_WATER_BOOST"
+REG__HOT_WATER_BOOST = "REG_HOT_WATER_BOOST"
 
 ###############################################################################
 # Operational time registers


### PR DESCRIPTION
Not sure why the the naming was changed, but apparently too eagerly and register name itself was ruined as well.
At some point noticed that boost dissapeared, started to investigate and appeared to be quite trivial issue.